### PR TITLE
att_compiler: Support for weights to lttoolbox binary format.

### DIFF
--- a/archive/apertium_lex_rule_proc.cc
+++ b/archive/apertium_lex_rule_proc.cc
@@ -58,7 +58,7 @@ map<int, LSRuleExe> rules;
 //map<wstring, TransExe> transducers; 
 Alphabet alphabet;
 State *initial_state;
-set<Node *> anfinals;
+map<Node *, double> anfinals;
 set<wchar_t> escaped;
 bool outOfWord = true;
 map<int, Transducer> transducers;
@@ -662,7 +662,10 @@ main (int argc, char** argv)
   initial_state = new State(pool);
   initial_state->init(te.getInitial());
 
-  anfinals.insert(te.getFinals().begin(), te.getFinals().end());
+  for(map<Node*, double>::const_iterator it = te.getFinals().begin(); it != te.getFinals().end(); it++)
+  {
+    anfinals.insert(pair<Node*, double>(it->first, it->second));
+  }
 
   //
   // Main loop

--- a/bkp.lrx_processor.cc
+++ b/bkp.lrx_processor.cc
@@ -131,7 +131,10 @@ LRXProcessor::init()
 {
   initial_state->init(transducer.getInitial());
 
-  anfinals.insert(transducer.getFinals().begin(), transducer.getFinals().end());
+  for(map<Node*, double>::const_iterator it = transducer.getFinals().begin(); it != transducer.getFinals().end(); it++)
+  {
+    anfinals.insert(pair<Node*, double>(it->first, it->second));
+  }
 
   escaped_chars.insert(L'[');
   escaped_chars.insert(L']');
@@ -181,8 +184,12 @@ LRXProcessor::recognisePattern(const wstring lu, const wstring op)
   first_state->init(recognisers[op].getInitial());
   State cur = *first_state;
 
-  set<Node *> end_states;
-  end_states.insert(recognisers[op].getFinals().begin(), recognisers[op].getFinals().end());
+  map<Node *, double> end_states;
+
+  for(map<Node*, double>::const_iterator it = recognisers[op].getFinals().begin(); it != recognisers[op].getFinals().end(); it++)
+  {
+    end_states.insert(pair<Node*, double>(it->first, it->second));
+  }
 
   bool readingTag = false;
   wstring tag = L"";

--- a/lrx_compiler.cc
+++ b/lrx_compiler.cc
@@ -81,6 +81,7 @@ LRXCompiler::LRXCompiler()
   outputGraph = false;
 
   currentRuleId = 0;
+  default_weight = 0.0000;
 
   initialState = transducer.getInitial();
   currentState = initialState;
@@ -257,13 +258,13 @@ LRXCompiler::procRule()
     }
     else if(name == LRX_COMPILER_RULE_ELEM)
     {
-      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState);
+      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState, default_weight);
       if(!alphabet.isSymbolDefined(ruleId.c_str()))
       { 
         alphabet.includeSymbol(ruleId.c_str());
       }
-      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(ruleId.c_str())), currentState);
-      transducer.setFinal(currentState);
+      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(ruleId.c_str())), currentState, default_weight);
+      transducer.setFinal(currentState, default_weight);
       currentState = initialState;
       return;
     }
@@ -319,7 +320,7 @@ LRXCompiler::procOr()
           {
             continue;
           }
-          transducer.linkStates(*it, currentState, 0);
+          transducer.linkStates(*it, currentState, 0, default_weight);
         }
       }
       break;
@@ -353,7 +354,7 @@ LRXCompiler::procMatch()
 
     for(wstring::iterator it = surface.begin(); it != surface.end(); it++)
     {
-      currentState = transducer.insertSingleTransduction(alphabet(*it, 0), currentState);
+      currentState = transducer.insertSingleTransduction(alphabet(*it, 0), currentState, default_weight);
     }
   }
   else
@@ -375,14 +376,14 @@ LRXCompiler::procMatch()
         fwprintf(stderr, L"        char: -\n");
       }
       int localLast = currentState;
-      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_CHAR>"), 0), currentState);
-      transducer.linkStates(currentState, localLast, 0);
+      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_CHAR>"), 0), currentState, default_weight);
+      transducer.linkStates(currentState, localLast, 0, default_weight);
     }
     else 
     {
       for(wstring::iterator it = lemma.begin(); it != lemma.end(); it++)
       {
-        currentState = transducer.insertSingleTransduction(alphabet(*it, 0), currentState);
+        currentState = transducer.insertSingleTransduction(alphabet(*it, 0), currentState, default_weight);
       }
     }
 
@@ -404,11 +405,11 @@ LRXCompiler::procMatch()
           }
           if(tag == L"<*>")
           {
-            currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState);
+            currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState, default_weight);
           }
           else
           {
-            currentState = transducer.insertSingleTransduction(alphabet(alphabet(tag.c_str()), 0), currentState);
+            currentState = transducer.insertSingleTransduction(alphabet(alphabet(tag.c_str()), 0), currentState, default_weight);
           }
           tag = L"";
           continue;
@@ -422,8 +423,8 @@ LRXCompiler::procMatch()
           fwprintf(stderr, L"        tag: %S\n", tag.c_str());
         }
         int localLast = currentState;
-        currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState);
-        transducer.linkStates(currentState, localLast, 0);
+        currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState, default_weight);
+        transducer.linkStates(currentState, localLast, 0, default_weight);
       }  
       else 
       {
@@ -436,7 +437,7 @@ LRXCompiler::procMatch()
         {
           fwprintf(stderr, L"        tag: %S\n", tag.c_str());
         }
-        currentState = transducer.insertSingleTransduction(alphabet(alphabet(tag.c_str()), 0), currentState);
+        currentState = transducer.insertSingleTransduction(alphabet(alphabet(tag.c_str()), 0), currentState, default_weight);
       }
     } 
     else
@@ -446,16 +447,16 @@ LRXCompiler::procMatch()
         fwprintf(stderr, L"        tag: -\n");
       }
       int localLast = currentState;
-      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState);
-      transducer.linkStates(currentState, localLast, 0);
+      currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"), 0), currentState, default_weight);
+      transducer.linkStates(currentState, localLast, 0, default_weight);
     }
   }
 
   if(xmlTextReaderIsEmptyElement(reader))
   {
     // If self-closing
-    currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState);
-    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<skip>")), currentState);
+    currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState, default_weight);
+    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<skip>")), currentState, default_weight);
     return;
   }
 
@@ -515,13 +516,13 @@ LRXCompiler::procSelect()
     fwprintf(stderr, L"        select: %S, %S\n", lemma.c_str(), tags.c_str());
   }
 
-  currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState);
-  currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<" + LRX_COMPILER_TYPE_SELECT + L">")), currentState);
+  currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState, default_weight);
+  currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<" + LRX_COMPILER_TYPE_SELECT + L">")), currentState, default_weight);
 
   for(wstring::iterator it = lemma.begin(); it != lemma.end(); it++)
   {
-    currentState = transducer.insertSingleTransduction(alphabet(0, *it), currentState);
-    localCurrentState = recogniser.insertSingleTransduction(alphabet(*it, 0), localCurrentState);
+    currentState = transducer.insertSingleTransduction(alphabet(0, *it), currentState, default_weight);
+    localCurrentState = recogniser.insertSingleTransduction(alphabet(*it, 0), localCurrentState, default_weight);
   }
 
   if(tags != L"")
@@ -542,14 +543,14 @@ LRXCompiler::procSelect()
         }
         if(tag == L"<*>")
         {
-          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
-          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
+          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
+          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
           key = key + L"<ANY_TAG>";
         }
         else
         {
-          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState);
-          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState);
+          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState, default_weight);
+          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState, default_weight);
           key = key + tag;
         }
         tag = L"";
@@ -563,10 +564,10 @@ LRXCompiler::procSelect()
       {
         fwprintf(stderr, L"        tag: %S\n", tag.c_str());
       }
-      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
+      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
       int localLast = localCurrentState;
-      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
-      recogniser.linkStates(localCurrentState, localLast, 0);
+      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
+      recogniser.linkStates(localCurrentState, localLast, 0, default_weight);
       key = key + L"<ANY_TAG>";
     }  
     else 
@@ -580,8 +581,8 @@ LRXCompiler::procSelect()
       {
         fwprintf(stderr, L"        tag: %S\n", tag.c_str());
       }
-      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState);
-      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState);
+      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState, default_weight);
+      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState, default_weight);
       key = key + tag;
     }
   } 
@@ -591,15 +592,15 @@ LRXCompiler::procSelect()
     {
       fwprintf(stderr, L"        tag: -\n");
     }
-    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
+    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
     int localLast = localCurrentState;
-    localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
-    recogniser.linkStates(localCurrentState, localLast, 0);
+    localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
+    recogniser.linkStates(localCurrentState, localLast, 0, default_weight);
     key = key + L"<ANY_TAG>";
   }
  
 
-  recogniser.setFinal(localCurrentState);
+  recogniser.setFinal(localCurrentState, default_weight);
 
   recognisers[key] = recogniser;
   if(debugMode) 
@@ -628,13 +629,13 @@ LRXCompiler::procRemove()
     fwprintf(stderr, L"        remove: %S, %S\n", lemma.c_str(), tags.c_str());
   }
 
-  currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState);
-  currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<" + LRX_COMPILER_TYPE_REMOVE + L">")), currentState);
+  currentState = transducer.insertSingleTransduction(alphabet(alphabet(L"<$>"), alphabet(L"<$>")), currentState, default_weight);
+  currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<" + LRX_COMPILER_TYPE_REMOVE + L">")), currentState, default_weight);
 
   for(wstring::iterator it = lemma.begin(); it != lemma.end(); it++)
   {
-    currentState = transducer.insertSingleTransduction(alphabet(0, *it), currentState);
-    localCurrentState = recogniser.insertSingleTransduction(alphabet(*it, 0), localCurrentState);
+    currentState = transducer.insertSingleTransduction(alphabet(0, *it), currentState, default_weight);
+    localCurrentState = recogniser.insertSingleTransduction(alphabet(*it, 0), localCurrentState, default_weight);
   }
 
   if(tags != L"")
@@ -655,14 +656,14 @@ LRXCompiler::procRemove()
         }
         if(tag == L"<*>")
         {
-          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
-          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
+          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
+          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
           key = key + L"<ANY_TAG>";
         }
         else
         {
-          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState);
-          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState);
+          currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState, default_weight);
+          localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState, default_weight);
           key = key + tag;
         }
         tag = L"";
@@ -676,10 +677,10 @@ LRXCompiler::procRemove()
       {
         fwprintf(stderr, L"        tag: %S\n", tag.c_str());
       }
-      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
+      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
       int localLast = localCurrentState;
-      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
-      recogniser.linkStates(localCurrentState, localLast, 0);
+      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
+      recogniser.linkStates(localCurrentState, localLast, 0, default_weight);
       key = key + L"<ANY_TAG>";
     }  
     else 
@@ -693,8 +694,8 @@ LRXCompiler::procRemove()
       {
         fwprintf(stderr, L"        tag: %S\n", tag.c_str());
       }
-      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState);
-      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState);
+      currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(tag.c_str())), currentState, default_weight);
+      localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(tag.c_str()),0), localCurrentState, default_weight);
       key = key + tag;
     }
   } 
@@ -704,15 +705,15 @@ LRXCompiler::procRemove()
     {
       fwprintf(stderr, L"        tag: -\n");
     }
-    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState);
+    currentState = transducer.insertSingleTransduction(alphabet(0, alphabet(L"<ANY_TAG>")), currentState, default_weight);
     int localLast = localCurrentState;
-    localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState);
-    recogniser.linkStates(localCurrentState, localLast, 0);
+    localCurrentState = recogniser.insertSingleTransduction(alphabet(alphabet(L"<ANY_TAG>"),0), localCurrentState, default_weight);
+    recogniser.linkStates(localCurrentState, localLast, 0, default_weight);
     key = key + L"<ANY_TAG>";
   }
  
 
-  recogniser.setFinal(localCurrentState);
+  recogniser.setFinal(localCurrentState, default_weight);
 
   recognisers[key] = recogniser;
   if(debugMode) 

--- a/lrx_compiler.h
+++ b/lrx_compiler.h
@@ -55,6 +55,8 @@ private:
   map<wstring, Transducer> recognisers; // keyed on pattern
   map<int, double> weights; // keyed on rule id
 
+  double default_weight;
+
   int initialState;
   int lastState;
   int currentState;

--- a/lrx_processor.cc
+++ b/lrx_processor.cc
@@ -138,7 +138,10 @@ LRXProcessor::init()
 {
   initial_state->init(transducer.getInitial());
 
-  anfinals.insert(transducer.getFinals().begin(), transducer.getFinals().end());
+  for(map<Node*, double>::const_iterator it = transducer.getFinals().begin(); it != transducer.getFinals().end(); it++)
+  {
+    anfinals.insert(pair<Node*, double>(it->first, it->second));
+  }
 
   escaped_chars.insert(L'[');
   escaped_chars.insert(L']');
@@ -188,8 +191,11 @@ LRXProcessor::recognisePattern(const wstring lu, const wstring op)
   first_state->init(recognisers[op].getInitial());
   State cur = *first_state;
 
-  set<Node *> end_states;
-  end_states.insert(recognisers[op].getFinals().begin(), recognisers[op].getFinals().end());
+  map<Node *, double> end_states;
+  for(map<Node*, double>::const_iterator it = recognisers[op].getFinals().begin(); it != recognisers[op].getFinals().end(); it++)
+  {
+    end_states.insert(pair<Node*, double>(it->first, it->second));
+  }
 
   bool readingTag = false;
   wstring tag = L"";

--- a/lrx_processor.h
+++ b/lrx_processor.h
@@ -84,7 +84,7 @@ private:
 
   vector<State> alive_states;
 
-  set<Node *> anfinals;
+  map<Node *, double> anfinals;
   set<wchar_t> escaped_chars;
   State *initial_state;
 
@@ -107,13 +107,13 @@ private:
   void evaluateRules();
 
   void processFlush(FILE *output,
-		    map<int, wstring > &sl,
-		    map<int, vector<wstring> > &tl,
-		    map<int, wstring > &blanks,
-		    map<int, pair<double, vector<State> > > &covers,
-		    pair<double, vector<State> > &empty_seq,
-		    map<pair<int, int>, vector<State> > &spans,
-		    int last_final);
+                    map<int, wstring > &sl,
+                    map<int, vector<wstring> > &tl,
+                    map<int, wstring > &blanks,
+                    map<int, pair<double, vector<State> > > &covers,
+                    pair<double, vector<State> > &empty_seq,
+                    map<pair<int, int>, vector<State> > &spans,
+                    int last_final);
 
   void processFlushME(FILE *output,
                       map<int, wstring > &sl,
@@ -141,4 +141,3 @@ public:
 };
 
 #endif /* __LRX_PROCESSOR_H__ */
-


### PR DESCRIPTION
Make necessary modifications in apertium-lex-tools to be
compatible with the new lttoolbox.

Related to https://github.com/apertium/lttoolbox/issues/2