### PR TITLE
Avoid stepping by <ANY_TAG> multiple times in parallel, closes #29

### DIFF
--- a/lrx_processor.cc
+++ b/lrx_processor.cc
@@ -1070,6 +1070,10 @@ LRXProcessor::processME(FILE *input, FILE *output)
       tag = readFullBlock(input, L'<', L'>');
       sl[pos] = sl[pos] + tag;
       val = static_cast<int>(alphabet(tag));
+      if(val == 0)
+      {
+        val = static_cast<int>(alphabet(L"<ANY_TAG>"));
+      }
       if(debugMode)
       {
         fwprintf(stderr, L"tag %S: %d\n", tag.c_str(), val);
@@ -1095,7 +1099,8 @@ LRXProcessor::processME(FILE *input, FILE *output)
           {
             fwprintf(stderr, L"  step: %S\n", res.c_str());
           }
-          s->step(val, alphabet(L"<ANY_TAG>"));
+          if(val == alphabet(L"<ANY_TAG>")) s->step(val);
+          else s->step(val, alphabet(L"<ANY_TAG>"));
         }
         else
         {

--- a/lrx_processor.cc
+++ b/lrx_processor.cc
@@ -1070,10 +1070,6 @@ LRXProcessor::processME(FILE *input, FILE *output)
       tag = readFullBlock(input, L'<', L'>');
       sl[pos] = sl[pos] + tag;
       val = static_cast<int>(alphabet(tag));
-      if(val == 0)
-      {
-        val = static_cast<int>(alphabet(L"<ANY_TAG>"));
-      }
       if(debugMode)
       {
         fwprintf(stderr, L"tag %S: %d\n", tag.c_str(), val);


### PR DESCRIPTION
In https://github.com/apertium/apertium-lex-tools/issues/29#issuecomment-524097839 I listed two possible solutions. I initially tried the second one because it seemed cleaner, but when I tested it on kir-eng it changed the output, so I'm going with the first one.