### PR TITLE
add <def-seq> and <seq>

### DIFF
--- a/src/lrx_compiler.cc
+++ b/src/lrx_compiler.cc
@@ -21,6 +21,7 @@
 using namespace std;
 
 wstring const LRXCompiler::LRX_COMPILER_LRX_ELEM        = L"lrx";
+wstring const LRXCompiler::LRX_COMPILER_METALRX_ELEM        = L"metalrx";
 wstring const LRXCompiler::LRX_COMPILER_DEFMACROS_ELEM  = L"def-macros";
 wstring const LRXCompiler::LRX_COMPILER_DEFMACRO_ELEM   = L"def-macro";
 wstring const LRXCompiler::LRX_COMPILER_DEFSEQS_ELEM    = L"def-seqs";
@@ -205,6 +206,10 @@ LRXCompiler::procNode()
     /* ignorar */
   }
   else if(nombre == LRX_COMPILER_LRX_ELEM)
+  {
+    /* ignorar */
+  }
+  else if(nombre == LRX_COMPILER_METALRX_ELEM)
   {
     /* ignorar */
   }

--- a/src/lrx_compiler.cc
+++ b/src/lrx_compiler.cc
@@ -21,9 +21,6 @@
 using namespace std;
 
 wstring const LRXCompiler::LRX_COMPILER_LRX_ELEM        = L"lrx";
-wstring const LRXCompiler::LRX_COMPILER_METALRX_ELEM        = L"metalrx";
-wstring const LRXCompiler::LRX_COMPILER_DEFMACROS_ELEM  = L"def-macros";
-wstring const LRXCompiler::LRX_COMPILER_DEFMACRO_ELEM   = L"def-macro";
 wstring const LRXCompiler::LRX_COMPILER_DEFSEQS_ELEM    = L"def-seqs";
 wstring const LRXCompiler::LRX_COMPILER_DEFSEQ_ELEM     = L"def-seq";
 wstring const LRXCompiler::LRX_COMPILER_RULES_ELEM      = L"rules";
@@ -206,10 +203,6 @@ LRXCompiler::procNode()
     /* ignorar */
   }
   else if(nombre == LRX_COMPILER_LRX_ELEM)
-  {
-    /* ignorar */
-  }
-  else if(nombre == LRX_COMPILER_METALRX_ELEM)
   {
     /* ignorar */
   }

--- a/src/lrx_compiler.h
+++ b/src/lrx_compiler.h
@@ -89,6 +89,7 @@ private:
 
 public:
   static wstring const LRX_COMPILER_LRX_ELEM;
+  static wstring const LRX_COMPILER_METALRX_ELEM;
   static wstring const LRX_COMPILER_DEFMACROS_ELEM;
   static wstring const LRX_COMPILER_DEFMACRO_ELEM;
   static wstring const LRX_COMPILER_DEFSEQS_ELEM;

--- a/src/lrx_compiler.h
+++ b/src/lrx_compiler.h
@@ -89,9 +89,6 @@ private:
 
 public:
   static wstring const LRX_COMPILER_LRX_ELEM;
-  static wstring const LRX_COMPILER_METALRX_ELEM;
-  static wstring const LRX_COMPILER_DEFMACROS_ELEM;
-  static wstring const LRX_COMPILER_DEFMACRO_ELEM;
   static wstring const LRX_COMPILER_DEFSEQS_ELEM;
   static wstring const LRX_COMPILER_DEFSEQ_ELEM;
   static wstring const LRX_COMPILER_RULES_ELEM;

--- a/src/lrx_compiler.h
+++ b/src/lrx_compiler.h
@@ -55,10 +55,12 @@ private:
   map<wstring, Transducer> recognisers; // keyed on pattern
   map<int, double> weights; // keyed on rule id
 
+  map<wstring, Transducer> sequences;
+
   int initialState;
   int lastState;
   int currentState;
-  bool inRepeat;
+  bool canSelect; // disallow <select>, <remove> inside <def-seq>, <repeat>
 
   int currentRuleId;
 
@@ -71,11 +73,13 @@ private:
   void procList();
   void procListMatch();
   void procRule();
+  void procDefSeq();
   void procOr();
   void procMatch();
   void procSelect();
   void procRemove();
   void procRepeat();
+  void procSeq();
 
   wstring attrib(wstring const &name);
 
@@ -84,6 +88,11 @@ private:
   double wtod(wstring);
 
 public:
+  static wstring const LRX_COMPILER_LRX_ELEM;
+  static wstring const LRX_COMPILER_DEFMACROS_ELEM;
+  static wstring const LRX_COMPILER_DEFMACRO_ELEM;
+  static wstring const LRX_COMPILER_DEFSEQS_ELEM;
+  static wstring const LRX_COMPILER_DEFSEQ_ELEM;
   static wstring const LRX_COMPILER_RULES_ELEM;
   static wstring const LRX_COMPILER_RULE_ELEM;
   static wstring const LRX_COMPILER_MATCH_ELEM;
@@ -91,6 +100,7 @@ public:
   static wstring const LRX_COMPILER_REMOVE_ELEM;
   static wstring const LRX_COMPILER_OR_ELEM;
   static wstring const LRX_COMPILER_REPEAT_ELEM;
+  static wstring const LRX_COMPILER_SEQ_ELEM;
 
   static wstring const LRX_COMPILER_SURFACE_ATTR;
   static wstring const LRX_COMPILER_LEMMA_ATTR;

--- a/testing/def-seq.expected
+++ b/testing/def-seq.expected
@@ -1,0 +1,3 @@
+^free<adj><sg>/gratis<adj><sg>$ ^whatever<n>/gloop<n>$
+^free<adj><sg>/libre<adj><sg>$ ^bloop<n>/gloop<n>$
+^free<adj><sg>/libre<adj><sg>$ ^shoop<n>/gloop<n>$

--- a/testing/def-seq.input
+++ b/testing/def-seq.input
@@ -1,0 +1,3 @@
+^free<adj><sg>/libre<adj><sg>/gratis<adj><sg>$ ^whatever<n>/gloop<n>$
+^free<adj><sg>/libre<adj><sg>/gratis<adj><sg>$ ^bloop<n>/gloop<n>$
+^free<adj><sg>/libre<adj><sg>/gratis<adj><sg>$ ^shoop<n>/gloop<n>$

--- a/testing/def-seq.xml
+++ b/testing/def-seq.xml
@@ -1,0 +1,21 @@
+<lrx>
+  <def-seqs>
+    <def-seq n="bloop">
+      <or>
+        <match lemma="bloop"/>
+        <match lemma="shoop"/>
+      </or>
+    </def-seq>
+  </def-seqs>
+  <rules>
+    <rule>
+	    <match lemma="free" tags="adj.*"><select lemma="gratis"/></match>
+    </rule>
+    <rule weight="3">
+      <match lemma="free" tags="adj.*">
+        <select lemma="libre"/>
+      </match>
+      <seq n="bloop"/>
+    </rule>
+  </rules>
+</lrx>


### PR DESCRIPTION
This PR adds support for `<def-seq>` and `<seq>`.

lrx-comp now expects a file along the lines of:
```xml
<lrx>
  <def-seqs>
    <def-seq n="blah">
      <or>
        ...
      </or>
    </def-seq>
  </def-seq>
  <rules>
    <rule>
      <match>
      <seq n="blah"/>
    </rule>
  </rules>
</lrx>
```
However, since I added `<lrx>` and `<def-seqs>` via the path of least resistance, existing rule files with `<rules>` as the root element will still compile.