### PR TITLE
off-by-one error in <repeat>

### DIFF
--- a/src/lrx_compiler.cc
+++ b/src/lrx_compiler.cc
@@ -887,7 +887,7 @@ LRXCompiler::procRepeat()
     cerr << L"): Lower bound on number of repetitions cannot be larger than upper bound." << endl;
     exit(EXIT_FAILURE);
   }
-  int count = upto - from + 1;
+  int count = upto - from;
   int oldstate = currentState;
   Transducer temp = transducer;
   transducer.clear();


### PR DESCRIPTION
I miscounted and had `<repeat>` inserting one more optional entry than it should have been.