### PR TITLE
Support <remove> rules in maxEnt (default) mode too 

### DIFF
--- a/src/lrx_processor.cc
+++ b/src/lrx_processor.cc
@@ -172,11 +172,6 @@ LRXProcessor::readFullBlock(FILE *input, wchar_t const delim1, wchar_t const del
 bool
 LRXProcessor::recognisePattern(const wstring lu, const wstring op)
 {
-  if(debugMode)
-  {
-    fwprintf(stderr, L"================================================\n");
-  }
-
   if(recognisers.count(op) < 1)
   {
     fwprintf(stderr, L"WARNING: Recogniser size 0 for key %S, skipping...\n", op.c_str());

--- a/src/lrx_processor.h
+++ b/src/lrx_processor.h
@@ -115,14 +115,14 @@ private:
                     map<pair<int, int>, vector<State> > &spans,
                     int last_final);
 
-  enum AppType { Select, Remove };
+  enum OpType { Select, Remove };
 
   void processFlushME(FILE *output,
                       map<int, wstring > &sl,
                       map<int, vector<wstring> > &tl,
                       map<int, wstring > &blanks,
                       map<int, map<wstring, double> > &scores,
-                      map<int, pair<wstring, AppType> > &operations);
+                      map<int, map<wstring, OpType> > &operations);
 
 public:
   static wstring const LRX_PROCESSOR_TAG_SELECT;

--- a/src/lrx_processor.h
+++ b/src/lrx_processor.h
@@ -115,11 +115,14 @@ private:
                     map<pair<int, int>, vector<State> > &spans,
                     int last_final);
 
+  enum AppType { Select, Remove };
+
   void processFlushME(FILE *output,
                       map<int, wstring > &sl,
                       map<int, vector<wstring> > &tl,
                       map<int, wstring > &blanks,
-                      map<int, map<wstring, double> > &scores);
+                      map<int, map<wstring, double> > &scores,
+                      map<int, pair<wstring, AppType> > &operations);
 
 public:
   static wstring const LRX_PROCESSOR_TAG_SELECT;

--- a/testing/issue37-noremove.expected
+++ b/testing/issue37-noremove.expected
@@ -1,0 +1,1 @@
+^,<cm>/,<cm>$ ^inlem<a>/selectfallback<b>$

--- a/testing/issue37-noremove.input
+++ b/testing/issue37-noremove.input
@@ -1,0 +1,1 @@
+^,<cm>/,<cm>$ ^inlem<a>/selectfallback<b>/notselected<c>/removeme<d>/notselectedeither<e>$

--- a/testing/issue37-noremove.xml
+++ b/testing/issue37-noremove.xml
@@ -1,0 +1,12 @@
+<rules>
+
+  <rule weight="1.61803">
+    <match lemma="inlem" tags="a"><select lemma="selectfallback"/></match>
+  </rule>
+
+  <rule weight="3.14159">
+    <match tags="*"/>
+    <match lemma="inlem" tags="a"><remove lemma="removeme"/></match>
+  </rule>
+
+</rules>

--- a/testing/issue37-remove.expected
+++ b/testing/issue37-remove.expected
@@ -1,0 +1,2 @@
+^a<a>/keepme<d>$
+^x<x>/keepme<c>/keepme<d>$

--- a/testing/issue37-remove.input
+++ b/testing/issue37-remove.input
@@ -1,0 +1,2 @@
+^a<a>/removemefirst<b>/thenremoveme<c>/keepme<d>$
+^x<x>/removemeonly<b>/keepme<c>/keepme<d>$

--- a/testing/issue37-remove.xml
+++ b/testing/issue37-remove.xml
@@ -1,0 +1,12 @@
+<rules>
+  <rule weight="3.14159">
+    <match lemma="a" tags="a"><remove lemma="removemefirst"/></match>
+  </rule>
+  <rule weight="2.71828">
+    <match lemma="a" tags="a"><remove lemma="thenremoveme"/></match>
+  </rule>
+
+  <rule weight="1.61803">
+    <match lemma="x" tags="x"><remove lemma="removemeonly"/></match>
+  </rule>
+</rules>


### PR DESCRIPTION
Fixes #37 

I see no changes in output from the nob-nno lrx on corpus runs (which does not use `<remove>` rules yet), and speed/memory seems the same. 