### PR TITLE
match unknowns - closes #39

### DIFF
--- a/testing/unknown.expected
+++ b/testing/unknown.expected
@@ -1,0 +1,2 @@
+^potato<n>/known<n>$ ^normal_word<adj>/normal_word<adj>$
+^potato<n>/unknown<n>$ ^*unknown_word/*unknown_word$

--- a/testing/unknown.input
+++ b/testing/unknown.input
@@ -1,0 +1,2 @@
+^potato<n>/known<n>/unknown<n>$ ^normal_word<adj>/normal_word<adj>$
+^potato<n>/known<n>/unknown<n>$ ^*unknown_word/*unknown_word$

--- a/testing/unknown.xml
+++ b/testing/unknown.xml
@@ -1,0 +1,11 @@
+<rules>
+  <rule>
+	  <match lemma="potato"><select lemma="known"/></match>
+  </rule>
+  <rule weight="3">
+    <match lemma="potato">
+      <select lemma="unknown"/>
+    </match>
+    <match tags=""/>
+  </rule>
+</rules>


### PR DESCRIPTION
This PR modifies the behavior of `<match tags=""/>` to match the behavior of `<match lemma=""/>` as discussed in #36 and #39.

One note is that this will now ignore extraneous periods in the tags attribute. So `<match tags="."/> == <match tags=""/>` and `<match tags="n...*"/> == <match tags="n.*"/>`. I can add a check to deal with this, if desired.

Most of the changes in the diff are due to a change in indentation.