### PR TITLE
ensure that branches of <or> have separate paths - closes #44

### DIFF
--- a/src/lrx_compiler.cc
+++ b/src/lrx_compiler.cc
@@ -342,6 +342,7 @@ LRXCompiler::procOr()
     fwprintf(stderr, L"    or: \n");
   }
 
+  int or_initial_state = currentState;
   vector<int> reachedStates;
   while(true)
   {
@@ -358,13 +359,13 @@ LRXCompiler::procOr()
 
     if(name == LRX_COMPILER_MATCH_ELEM)
     {
-      currentState = lastState;
+      currentState = transducer.insertNewSingleTransduction(0, or_initial_state);
       procMatch();
       reachedStates.push_back(currentState);
     }
     else if(name == LRX_COMPILER_SEQ_ELEM)
     {
-      currentState = lastState;
+      currentState = transducer.insertNewSingleTransduction(0, or_initial_state);
       procSeq();
       reachedStates.push_back(currentState);
     }


### PR DESCRIPTION
Number of tricks in my toolbelt? Apparently only 1.

This prevents
```xml
<or>
  <match tags="x"/>
  <match lemma="blah"/>
</or>
```
from matching things that only have `blah` as a suffix.

The issue is that that structure will have states like
```
1	2	<ANY_CHAR>	ε	0.000000	
2	1	ε	ε	0.000000	
1	3	b	ε	0.000000	
```
where the `<ANY_CHAR>`-`ε` loop *should* only go with `<x>`, but the path `1-2-1-3` is possible and thus prefixes are possible.

This could also be fixed by changing `procMatch()` to generate an `<ANY_CHAR>` loop at `2` rather than an `ε` back to `1`.