### PR TITLE
option to change glob behavior

### DIFF
--- a/src/lrx_compiler.h
+++ b/src/lrx_compiler.h
@@ -53,6 +53,8 @@ private:
   int32_t any_lower = 0;
   int32_t word_boundary = 0;
 
+  bool globIsStar = false;
+
   bool debugMode = false;
   bool outputGraph = false;
   UFILE* debug_output;
@@ -104,6 +106,9 @@ public:
   static UString const LRX_COMPILER_WEIGHT_ATTR;
   static UString const LRX_COMPILER_FROM_ATTR;
   static UString const LRX_COMPILER_UPTO_ATTR;
+  static UString const LRX_COMPILER_GLOB_ATTR;
+  static UString const LRX_COMPILER_GLOB_PLUS_VAL;
+  static UString const LRX_COMPILER_GLOB_STAR_VAL;
 
   static UString const LRX_COMPILER_TYPE_MATCH;
   static UString const LRX_COMPILER_TYPE_SELECT;

--- a/testing/globbing.expected
+++ b/testing/globbing.expected
@@ -1,0 +1,13 @@
+^blah<n>/bloop<n>$ ^*hiya/*hiya$
+^blah<n>/bloop<n>$ ^hiya<n>/hiya<n>$
+^blah<n>/bloop<n>$ ^hiya<n><nom><sg>/hiya<n>$
+
+^blah<n>/bloop<n>$ ^hi<n><nom><sg>/hi<n>$
+^blah<n>/shoop<n>$ ^hi<n>/hiya<n>$
+
+^blah<n>/shoop<n>$ ^hi<ij><q>/hiya<n>$
+^blah<n>/bloop<n>$ ^hi<ij><n><q>/hiya<n>$
+
+^blah<n>/bloop<n>$ ^hi<v><itj>/hiya<n>$
+^blah<n>/bloop<n>$ ^hi<v><inf><itj>/hiya<n>$
+^blah<n>/bloop<n>$ ^hi<v><inf><pl><itj>/hiya<n>$

--- a/testing/globbing.input
+++ b/testing/globbing.input
@@ -1,0 +1,13 @@
+^blah<n>/bloop<n>/shoop<n>$ ^*hiya/*hiya$
+^blah<n>/bloop<n>/shoop<n>$ ^hiya<n>/hiya<n>$
+^blah<n>/bloop<n>/shoop<n>$ ^hiya<n><nom><sg>/hiya<n>$
+
+^blah<n>/bloop<n>/shoop<n>$ ^hi<n><nom><sg>/hi<n>$
+^blah<n>/bloop<n>/shoop<n>$ ^hi<n>/hiya<n>$
+
+^blah<n>/bloop<n>/shoop<n>$ ^hi<ij><q>/hiya<n>$
+^blah<n>/bloop<n>/shoop<n>$ ^hi<ij><n><q>/hiya<n>$
+
+^blah<n>/bloop<n>/shoop<n>$ ^hi<v><itj>/hiya<n>$
+^blah<n>/bloop<n>/shoop<n>$ ^hi<v><inf><itj>/hiya<n>$
+^blah<n>/bloop<n>/shoop<n>$ ^hi<v><inf><pl><itj>/hiya<n>$

--- a/testing/globbing.xml
+++ b/testing/globbing.xml
@@ -1,0 +1,33 @@
+<lrx glob="star">
+	<rules>
+		<rule weight="1.0">
+			<match lemma="blah" tags="n">
+				<select lemma="bloop"/>
+			</match>
+			<match lemma="hiya" tags="*"/>
+		</rule>
+		<rule weight="1.0">
+			<match lemma="blah" tags="n">
+				<select lemma="bloop"/>
+			</match>
+			<match lemma="hi" tags="n.+"/>
+		</rule>
+		<rule weight="1.0">
+			<match lemma="blah" tags="n">
+				<select lemma="bloop"/>
+			</match>
+			<match lemma="hi" tags="ij.?.q"/>
+		</rule>
+		<rule weight="1.0">
+			<match lemma="blah" tags="n">
+				<select lemma="bloop"/>
+			</match>
+			<match lemma="hi" tags="v.*.itj"/>
+		</rule>
+		<rule weight="0.1">
+			<match lemma="blah" tags="n">
+				<select lemma="shoop"/>
+			</match>
+		</rule>
+	</rules>
+</lrx>


### PR DESCRIPTION
As suggested in #49, this PR adds an optional attribute `glob`, specifying the behavior of `*` in tag lists.

If `glob="plus"` is present on `<lrx>` or `<rules>`, then `*` will match 1 or more tags, as before. This will also be the behavior if `glob` is not specified anywhere, for backwards compatibility.

If `glob="star"` is present, then `*` will match 0 or more tags, `+` will match 1 or more tags, and `?` will match any single tag.

Closes #49
Closes #66

@unhammer @ftyers @hectoralos @jonorthwash 