### PR TITLE
support macros

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
            sudo apt-get -qy update
            sudo apt-get -qfy install apt-utils wget ca-certificates
            wget -q https://apertium.projectjj.com/apt/install-nightly.sh -O - | sudo bash
-           sudo apt-get -qfy install --no-install-recommends build-essential automake autotools-dev pkg-config libxml2-dev libirstlm-dev lttoolbox-dev python3-dev python3-setuptools swig
+           sudo apt-get -qfy install --no-install-recommends build-essential automake autotools-dev pkg-config libxml2-dev libxml2-utils libirstlm-dev lttoolbox-dev python3-dev python3-setuptools swig
     - name: autoreconf
       run: autoreconf -fvi
     - name: configure

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ src/irstlm-ranker
 src/process-tagger-output
 src/yasmet
 src/multitrans
+src/apertium-validate-lrx
 stamp-h1
 
 /python/apertium_lex_tools.py

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 AC_PREREQ(2.61)
 
 m4_define([PKG_VERSION_MAJOR], [0])
-m4_define([PKG_VERSION_MINOR], [3])
-m4_define([PKG_VERSION_PATCH], [1])
+m4_define([PKG_VERSION_MINOR], [4])
+m4_define([PKG_VERSION_PATCH], [0])
 
 m4_define([required_libxml_version], [2.6.17])
-m4_define([required_lttoolbox_version], [3.6.0])
+m4_define([required_lttoolbox_version], [3.6.5])
 
 AC_INIT([apertium-lex-tools], [PKG_VERSION_MAJOR.PKG_VERSION_MINOR.PKG_VERSION_PATCH], [apertium-stuff@lists.sourceforge.net])
 AM_INIT_AUTOMAKE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,4 +32,17 @@ if HAVE_IRSTLM
     bin_PROGRAMS += irstlm-ranker
 endif
 
-EXTRA_DIST = lrx_compiler.h lrx_processor.h multi_translator.h tagger_output_processor.h
+apertium-validate-lrx: Makefile.am validate-lrx.sh
+	@echo "Creating apertium-validate-lrx script"
+	@cat validate-lrx.sh > $@
+	@echo "xmllint --dtdvalid \"$(prefix)\"/share/apertium-lex-tools/lrx.dtd --noout \"\$$FILE1\"" >> $@
+	@chmod a+x $@
+
+GENERATEDSCRIPTS = apertium-validate-lrx
+bin_SCRIPTS = $(GENERATEDSCRIPTS)
+CLEANFILES = *~ $(GENERATEDSCRIPTS)
+
+apertium_lex_toolsdir = $(prefix)/share/apertium-lex-tools
+apertium_lex_tools_DATA = lrx.dtd
+
+EXTRA_DIST = lrx_compiler.h lrx_processor.h multi_translator.h tagger_output_processor.h validate-lrx.sh

--- a/src/lrx.dtd
+++ b/src/lrx.dtd
@@ -29,7 +29,7 @@
 <!ATTLIST def-macro
   n ID #REQUIRED
   nodes CDATA #IMPLIED
-  strs CDATA #IMPLIED
+  npar CDATA #IMPLIED
 >
 
 <!ELEMENT def-seqs (def-seq+)>

--- a/src/lrx.dtd
+++ b/src/lrx.dtd
@@ -1,0 +1,129 @@
+<!--
+   Copyright (C) 2022 Apertium
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not <https://www.gnu.org/licenses/>.
+
+      DTD for the format of lexical selection rules
+-->
+
+<!ELEMENT lrx (rules|def-macros|def-seqs)*>
+<!ATTLIST lrx glob (plus|star) #IMPLIED>
+
+<!ELEMENT rules (rule|macro)*>
+<!ATTLIST rules glob (plus|star) #IMPLIED>
+
+<!ELEMENT def-macros (def-macro*)>
+
+<!ELEMENT def-macro (rule|macro)*>
+<!ATTLIST def-macro
+  n ID #REQUIRED
+  nodes CDATA #REQUIRED
+  strs CDATA #REQUIRED
+>
+
+<!ELEMENT def-seqs (def-seq+)>
+
+<!ELEMENT def-seq (match|or|repeat|seq|begin)*>
+<!ATTLIST def-seq n ID #REQUIRED>
+
+<!ELEMENT rule (match|or|repeat|seq|begin)*>
+<!ATTLIST rule
+  weight CDATA #IMPLIED
+  c CDATA #IMPLIED
+
+  pweight CDATA #IMPLIED
+  pc CDATA #IMPLIED
+>
+
+<!ELEMENT or (match|or|repeat|seq|begin)*>
+
+<!ELEMENT repeat (match|or|repeat|seq|begin)*>
+<!ATTLIST repeat
+  from CDATA #IMPLIED
+  upto CDATA #IMPLIED
+
+  pfrom CDATA #IMPLIED
+  pupto CDATA #IMPLIED
+>
+
+<!ELEMENT begin EMPTY>
+
+<!ELEMENT seq EMPTY>
+<!ATTLIST seq
+  n IDREF #IMPLIED
+  pn IDREF #IMPLIED
+>
+
+<!ELEMENT macro (with-param*)>
+<!ATTLIST macro
+  n IDREF #IMPLIED
+  pn IDREF #IMPLIED
+>
+
+<!ELEMENT with-param (match|or|repeat|seq|begin)*>
+<!ATTLIST with-param
+  v CDATA #IMPLIED
+  pv CDATA #IMPLIED
+>
+
+<!ELEMENT match (select|remove)?>
+<!ATTLIST match
+  lemma CDATA #IMPLIED
+  suffix CDATA #IMPLIED
+  contains CDATA #IMPLIED
+  case CDATA #IMPLIED
+  surface CDATA #IMPLIED
+  tags CDATA #IMPLIED
+
+  plemma CDATA #IMPLIED
+  psuffix CDATA #IMPLIED
+  pcontains CDATA #IMPLIED
+  pcase CDATA #IMPLIED
+  psurface CDATA #IMPLIED
+  ptags CDATA #IMPLIED
+>
+
+<!ELEMENT select EMPTY>
+<!ATTLIST select
+  lemma CDATA #IMPLIED
+  suffix CDATA #IMPLIED
+  contains CDATA #IMPLIED
+  case CDATA #IMPLIED
+  surface CDATA #IMPLIED
+  tags CDATA #IMPLIED
+
+  plemma CDATA #IMPLIED
+  psuffix CDATA #IMPLIED
+  pcontains CDATA #IMPLIED
+  pcase CDATA #IMPLIED
+  psurface CDATA #IMPLIED
+  ptags CDATA #IMPLIED
+>
+
+<!ELEMENT remove EMPTY>
+<!ATTLIST remove
+  lemma CDATA #IMPLIED
+  suffix CDATA #IMPLIED
+  contains CDATA #IMPLIED
+  case CDATA #IMPLIED
+  surface CDATA #IMPLIED
+  tags CDATA #IMPLIED
+
+  plemma CDATA #IMPLIED
+  psuffix CDATA #IMPLIED
+  pcontains CDATA #IMPLIED
+  pcase CDATA #IMPLIED
+  psurface CDATA #IMPLIED
+  ptags CDATA #IMPLIED
+>

--- a/src/lrx.dtd
+++ b/src/lrx.dtd
@@ -28,8 +28,8 @@
 <!ELEMENT def-macro (rule|macro)*>
 <!ATTLIST def-macro
   n ID #REQUIRED
-  nodes CDATA #REQUIRED
-  strs CDATA #REQUIRED
+  nodes CDATA #IMPLIED
+  strs CDATA #IMPLIED
 >
 
 <!ELEMENT def-seqs (def-seq+)>
@@ -37,18 +37,17 @@
 <!ELEMENT def-seq (match|or|repeat|seq|begin)*>
 <!ATTLIST def-seq n ID #REQUIRED>
 
-<!ELEMENT rule (match|or|repeat|seq|begin)*>
+<!ELEMENT rule (match|or|repeat|seq|begin|param)*>
 <!ATTLIST rule
   weight CDATA #IMPLIED
   c CDATA #IMPLIED
 
   pweight CDATA #IMPLIED
-  pc CDATA #IMPLIED
 >
 
-<!ELEMENT or (match|or|repeat|seq|begin)*>
+<!ELEMENT or (match|or|repeat|seq|begin|param)*>
 
-<!ELEMENT repeat (match|or|repeat|seq|begin)*>
+<!ELEMENT repeat (match|or|repeat|seq|begin|param)*>
 <!ATTLIST repeat
   from CDATA #IMPLIED
   upto CDATA #IMPLIED
@@ -71,10 +70,16 @@
   pn IDREF #IMPLIED
 >
 
-<!ELEMENT with-param (match|or|repeat|seq|begin)*>
+<!ELEMENT with-param (match|or|repeat|seq|begin|param)*>
 <!ATTLIST with-param
   v CDATA #IMPLIED
   pv CDATA #IMPLIED
+>
+
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+  n CDATA #IMPLIED
+  pn CDATA #IMPLIED
 >
 
 <!ELEMENT match (select|remove)?>

--- a/src/lrx_compiler.cc
+++ b/src/lrx_compiler.cc
@@ -54,7 +54,7 @@ UString const LRXCompiler::LRX_COMPILER_COMMENT_ATTR    = "c"_u;
 UString const LRXCompiler::LRX_COMPILER_NAME_ATTR       = "n"_u;
 UString const LRXCompiler::LRX_COMPILER_VALUE_ATTR      = "v"_u;
 UString const LRXCompiler::LRX_COMPILER_NODES_ATTR      = "nodes"_u;
-UString const LRXCompiler::LRX_COMPILER_STRS_ATTR       = "strs"_u;
+UString const LRXCompiler::LRX_COMPILER_NPAR_ATTR       = "npar"_u;
 UString const LRXCompiler::LRX_COMPILER_FROM_ATTR       = "from"_u;
 UString const LRXCompiler::LRX_COMPILER_UPTO_ATTR       = "upto"_u;
 UString const LRXCompiler::LRX_COMPILER_GLOB_ATTR       = "glob"_u;
@@ -587,7 +587,7 @@ LRXCompiler::procMacro(xmlNode* node)
   vector<UString> current_strings;
   vector<xmlNode*> current_nodes;
   int nodes = StringUtils::stoi(getattr(nextMacro, LRX_COMPILER_NODES_ATTR, "0"_u));
-  int strs = StringUtils::stoi(getattr(nextMacro, LRX_COMPILER_STRS_ATTR, "0"_u));
+  int npar = StringUtils::stoi(getattr(nextMacro, LRX_COMPILER_NPAR_ATTR, "0"_u));
   for (auto ch : children(node)) {
     if (name(ch) != LRX_COMPILER_WITH_PARAM_ELEM) {
       error_and_die(ch, "Unexpected inclusion of <%S> in <macro>.", name(ch).c_str());
@@ -602,8 +602,8 @@ LRXCompiler::procMacro(xmlNode* node)
   if (current_nodes.size() != nodes) {
     error_and_die(node, "Macro '%S' expects %d node parameters, but %d were given.", macname.c_str(), nodes, macro_node_vars.size());
   }
-  if (current_strings.size() != strs) {
-    error_and_die(node, "Macro '%S' expects %d string parameters, but %d were given.", macname.c_str(), strs, macro_string_vars.size());
+  if (current_strings.size() != npar) {
+    error_and_die(node, "Macro '%S' expects %d string parameters, but %d were given.", macname.c_str(), npar, macro_string_vars.size());
   }
   current_strings.swap(macro_string_vars);
   current_nodes.swap(macro_node_vars);

--- a/src/lrx_compiler.h
+++ b/src/lrx_compiler.h
@@ -112,7 +112,7 @@ public:
   static UString const LRX_COMPILER_COMMENT_ATTR;
   static UString const LRX_COMPILER_NAME_ATTR;
   static UString const LRX_COMPILER_NODES_ATTR;
-  static UString const LRX_COMPILER_STRS_ATTR;
+  static UString const LRX_COMPILER_NPAR_ATTR;
   static UString const LRX_COMPILER_VALUE_ATTR;
   static UString const LRX_COMPILER_WEIGHT_ATTR;
   static UString const LRX_COMPILER_FROM_ATTR;

--- a/src/process_tagger_output.cc
+++ b/src/process_tagger_output.cc
@@ -111,8 +111,8 @@ void processTaggerOutput(FSTProcessor *bilingual) {
 
 int main(int argc, char **argv) {
 	if (argc != 2) {
-		std::cout << "Usage: " << argv[0] << " bidix_bin_file" << endl;
-		std::cout << "with output from pretransfer on standard input." << endl;
+		std::cout << "Usage: " << argv[0] << " bidix_bin_file" << std::endl;
+		std::cout << "with output from pretransfer on standard input." << std::endl;
 		exit(-1);
 	}
 

--- a/src/validate-lrx.sh
+++ b/src/validate-lrx.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [[ $# != 1 ]]; then
+    echo "USAGE: $(basename "$0") <input_file>"
+    exit 1
+fi
+
+FILE1=$1
+
+if [[ ! -e $FILE1 ]]; then
+    echo "ERROR: '$1' file not found"
+    exit 1
+fi

--- a/testing/bug1.xml
+++ b/testing/bug1.xml
@@ -1,4 +1,4 @@
 <rules>
-<rule comment="193"><match lemma="garrantzi" tags="*"><select lemma="importancia"/></match></rule>
-<rule comment="7"><match lemma="garratz" tags="*"><select lemma="ácido"/></match></rule>
+<rule c="193"><match lemma="garrantzi" tags="*"><select lemma="importancia"/></match></rule>
+<rule c="7"><match lemma="garratz" tags="*"><select lemma="ácido"/></match></rule>
 </rules>

--- a/testing/bug2.xml
+++ b/testing/bug2.xml
@@ -1,5 +1,5 @@
 <rules>
-<rule comment="103"><match lemma="област"><select lemma="area"/></match></rule>
-<rule comment="44"><match lemma="граничен"><select lemma="border"/></match></rule>
-<rule comment="32"><match lemma="пограничен"><select lemma="border"/></match></rule>
+<rule c="103"><match lemma="област"><select lemma="area"/></match></rule>
+<rule c="44"><match lemma="граничен"><select lemma="border"/></match></rule>
+<rule c="32"><match lemma="пограничен"><select lemma="border"/></match></rule>
 </rules>

--- a/testing/macro.expected
+++ b/testing/macro.expected
@@ -1,0 +1,3 @@
+^hi<x>/ho<x>$ ^yi<n><sg>/ya<n><sg>$ ^ho<y>/ha<y>$ ^yo<n>/blah<q>$
+^a<x>/a<x>$ ^b<y>/noodle<z>$
+^octopi<x>/a<x>$ ^potato<y>/noodle<z>$

--- a/testing/macro.input
+++ b/testing/macro.input
@@ -1,0 +1,3 @@
+^hi<x>/ho<x>$ ^yi<n><sg>/ya<n><sg>$ ^ho<y>/ha<y>$ ^yo<n>/blah<q>/bloop<r>$
+^a<x>/a<x>$ ^b<y>/b<z>/noodle<z>$
+^octopi<x>/a<x>$ ^potato<y>/b<z>/noodle<z>$

--- a/testing/macro.xml
+++ b/testing/macro.xml
@@ -1,13 +1,13 @@
 <lrx>
 	<def-macros>
-		<def-macro n="n" nodes="2" strs="0">
+		<def-macro n="n" nodes="2" npar="0">
 			<rule>
 				<param n="1"/>
 				<match tags="n.*"/>
 				<param n="2"/>
 			</rule>
 		</def-macro>
-		<def-macro n="s" nodes="0" strs="2">
+		<def-macro n="s" nodes="0" npar="2">
 			<rule>
 				<match plemma="1"/>
 				<match plemma="2">
@@ -15,7 +15,7 @@
 				</match>
 			</rule>
 		</def-macro>
-		<def-macro n="nest" strs="1">
+		<def-macro n="nest" npar="1">
 			<macro n="s">
 				<with-param pv="1"/>
 				<with-param v="potato"/>

--- a/testing/macro.xml
+++ b/testing/macro.xml
@@ -1,0 +1,45 @@
+<lrx>
+	<def-macros>
+		<def-macro n="n" nodes="2" strs="0">
+			<rule>
+				<param n="1"/>
+				<match tags="n.*"/>
+				<param n="2"/>
+			</rule>
+		</def-macro>
+		<def-macro n="s" nodes="0" strs="2">
+			<rule>
+				<match plemma="1"/>
+				<match plemma="2">
+					<select lemma="noodle"/>
+				</match>
+			</rule>
+		</def-macro>
+		<def-macro n="nest" strs="1">
+			<macro n="s">
+				<with-param pv="1"/>
+				<with-param v="potato"/>
+			</macro>
+		</def-macro>
+	</def-macros>
+	<rules>
+		<macro n="n">
+			<with-param>
+				<match lemma="hi"/>
+			</with-param>
+			<with-param>
+				<match lemma="ho"/>
+				<match lemma="yo">
+					<select lemma="blah"/>
+				</match>
+			</with-param>
+		</macro>
+		<macro n="s">
+			<with-param v="a"/>
+			<with-param v="b"/>
+		</macro>
+		<macro n="nest">
+			<with-param v="octopi"/>
+		</macro>
+	</rules>
+</lrx>

--- a/testing/run
+++ b/testing/run
@@ -29,7 +29,7 @@ for xml in *.xml; do
     test=${xml%%.xml}
     rm -f "$test.{output,bin}"
     if ! (
-			../src/apertium-validate-lrx "$test.xml" &&
+			xmllint --dtdvalid ../src/lrx.dtd --noout "$test.xml" &&
 				../src/lrx-comp "$test.xml" "$test.bin" &> >(err "$test") &&
                 ../src/lrx-proc -m -z "$test.bin" < "$test.input" > "$test.output" 2> >(err "$test") &&
                 diff -au "$test.expected" "$test.output" | colournul

--- a/testing/run
+++ b/testing/run
@@ -29,7 +29,8 @@ for xml in *.xml; do
     test=${xml%%.xml}
     rm -f "$test.{output,bin}"
     if ! (
-            ../src/lrx-comp "$test.xml" "$test.bin" &> >(err "$test") &&
+			../src/apertium-validate-lrx "$test.xml" &&
+				../src/lrx-comp "$test.xml" "$test.bin" &> >(err "$test") &&
                 ../src/lrx-proc -m -z "$test.bin" < "$test.input" > "$test.output" 2> >(err "$test") &&
                 diff -au "$test.expected" "$test.output" | colournul
         )


### PR DESCRIPTION
Closes #33
Closes #55

This PR adds support for macros. As with previous metalrx features, this change will have no effect until references to `apertium-metalrx` are removed from the makefile, so no immediate action will be needed on the part of pair maintainers if this is merged.

Macros are defined like this:

```xml
<def-macros>
  <def-macro n="some_name" nodes="2" strs="1">
    <rule> ... </rule>
    ...
  </def-macro>
```
Where `strs="1"` specifies that is macro takes 1 string parameter and `nodes="2"` that it takes 2 node parameters.

The macro is then invoked as

```xml
<rules>
  <macro n="some_name">
    <with-param v="1st string param"/>
    <with-param>
      <match lemma="..."/>
    </with-param>
    <with-param>
      <match/>
      <match tags="sent"/>
    </with-param>
  </macro>
</rules>
```
That is, `<with-param>` containing other nodes is a node parameter and `<with-param>` with the `v=` attribute is a string parameter.

Node parameters can be inserted into a rule with `<param n="1"/>` and string parameters by placing a `p` before an attribute like `<match plemma="1"/>`.

I'm open to suggestions if a different syntax would be preferable.